### PR TITLE
Added build.sh for Linux and MacOS and made it compile on MacOS.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,5 +5,5 @@ if [ ! -d "./build" ]; then
 fi
 
 pushd build
-clang ../source/data_desk_main.c -DBUILD_LINUX -o ../source/data_desk
+clang ../source/data_desk_main.c -DBUILD_LINUX -o ./data_desk
 popd

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ ! -d "./build" ]; then 
+    mkdir build 
+fi
+
+pushd build
+clang ../source/data_desk_main.c -DBUILD_LINUX -o ../source/data_desk
+popd

--- a/source/data_desk_custom.c
+++ b/source/data_desk_custom.c
@@ -31,7 +31,7 @@ DataDeskCustomLoad(char *custom_dll_path)
         custom.CleanUpCallback = (void *)GetProcAddress(custom.custom_dll, "DataDeskCustomCleanUpCallback");
     }
 #elif BUILD_LINUX
-    custom.custom_dll = dlopen(custom_dll_path);
+    custom.custom_dll = dlopen(custom_dll_path, RTLD_NOW);
     if(custom.custom_dll)
     {
         custom.InitCallback = dlsym(custom.custom_dll, "DataDeskCustomInitCallback");

--- a/source/data_desk_main.c
+++ b/source/data_desk_main.c
@@ -9,6 +9,7 @@
 // NOTE(rjf): C Runtime Library
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
 
 // NOTE(rjf): Data Desk Code
 #include "data_desk.h"


### PR DESCRIPTION
I added a build.sh file to compile with clang.

I also fixed a few errors such as missing include for stdarg.h and dlopen being called with just one parameter when it requires two.

I also noticed clang reporting 8 warnings, some of them were from useless if statements in data_desk_parse.c like `if(RequireTokenType(tokenizer, TOKEN_tag, &tag));`.  

I would fix them but I thought I'd ask first if they are intentional or not. If they are intentional I and we shouldn't mess with them then I will add the appropriate flags to the compiler invocation to ignore those specific warnings, though I think it's better if we fix them.