### PR TITLE
only zero terminate if malloc didn't fail

### DIFF
--- a/source/data_desk_utilities.c
+++ b/source/data_desk_utilities.c
@@ -148,10 +148,10 @@ LoadEntireFileAndNullTerminate(char *filename)
         unsigned int file_size = ftell(file);
         fseek(file, 0, SEEK_SET);
         result = malloc(file_size+1);
-        result[file_size] = 0;
         if(result)
         {
             fread(result, 1, file_size, file);
+            result[file_size] = 0;
         }
         fclose(file);
     }


### PR DESCRIPTION
There's still an issue when fread() detects a read error. Could be checked with ferror(file)