### PR TITLE
Evaluate constant numeric identifiers in DataDeskInterpretNumericExpressionAsInteger

### DIFF
--- a/source/data_desk.h
+++ b/source/data_desk.h
@@ -986,18 +986,12 @@ DataDeskInterpretNumericExpressionAsInteger(DataDeskNode *root)
             }
             case DataDeskNodeType_Identifier:
             {
-                if (root->children_list_head)
-                {
-                    result = DataDeskInterpretNumericExpressionAsInteger(root->children_list_head);
-                }
+                result = DataDeskInterpretNumericExpressionAsInteger(root->children_list_head);
                 break;
             }
             case DataDeskNodeType_ConstantDefinition:
             {
-                if (root->children_list_head)
-                {
-                    result = DataDeskInterpretNumericExpressionAsInteger(root->children_list_head);
-                }
+                result = DataDeskInterpretNumericExpressionAsInteger(root->children_list_head);
                 break;
             }
             case DataDeskNodeType_UnaryOperator:

--- a/source/data_desk.h
+++ b/source/data_desk.h
@@ -984,7 +984,22 @@ DataDeskInterpretNumericExpressionAsInteger(DataDeskNode *root)
                 result = DataDeskCStringToInt(root->string);
                 break;
             }
-            
+            case DataDeskNodeType_Identifier:
+            {
+                if (root->children_list_head)
+                {
+                    result = DataDeskInterpretNumericExpressionAsInteger(root->children_list_head);
+                }
+                break;
+            }
+            case DataDeskNodeType_ConstantDefinition:
+            {
+                if (root->children_list_head)
+                {
+                    result = DataDeskInterpretNumericExpressionAsInteger(root->children_list_head);
+                }
+                break;
+            }
             case DataDeskNodeType_UnaryOperator:
             {
                 DataDeskUnaryOperatorType unary_operator_type = root->sub_type;


### PR DESCRIPTION
Very simple change to meet a requirement for a project of mine.
I think that this change would be beneficial to other people who use data_desk, while still fitting the definitions outlined in the readme.

Say for instance in my .ds file I defined the following constants:
```
CHUNK_WIDTH :: 16
CHUNK_HEIGHT :: 64
```
And in a struct, I want an array member which has a size based on those constants:
```
Chunk :: struct 
{  
    ... 
    blocks : uint8_t[CHUNK_WIDTH * CHUNK_HEIGHT]; 
    ...  
}  
```
In my custom layer I wanted to know the size of this array, so I would try:
```
    ...  
    int size = 1;  
    DataDeskNode *base_type, *array_size_expression;  
    if (DataDeskIsArrayType(node, &base_type, &array_size_expression))  
    {  
        node = base_type;  
        size = DataDeskInterpretNumericExpressionAsInteger(array_size_expression);  
    }  
    return size;  
```
but this returned zero before the change.
This change causes the function to act as I expect, returning 1024.
