### PR TITLE
[Fix] Crash on invalid characters

### DIFF
--- a/source/data_desk_parse.c
+++ b/source/data_desk_parse.c
@@ -805,7 +805,6 @@ ParseType(ParseContext *context, Tokenizer *tokenizer)
 
         if(!array_expr)
         {
-            ParseContextPushError(context, tokenizer, "Invalid array expression.");
             goto end_parse;
         }
         
@@ -999,8 +998,16 @@ ParseDeclarationBody(ParseContext *context, Tokenizer *tokenizer, Token name)
     {
         DataDeskNode *initialization = 0;
         initialization = ParseExpression(context, tokenizer);
+
+        if(!initialization)
+        {
+            goto end_parse;
+        }
+
         root->declaration.initialization = InsertChild(initialization, root);
     }
+
+    end_parse:;
     return root;
 }
 

--- a/source/data_desk_parse.c
+++ b/source/data_desk_parse.c
@@ -802,6 +802,12 @@ ParseType(ParseContext *context, Tokenizer *tokenizer)
         type->sub_type = DataDeskTypeDecoratorType_Array;
         
         DataDeskNode *array_expr = ParseExpression(context, tokenizer);
+
+        if(!array_expr)
+        {
+            ParseContextPushError(context, tokenizer, "Invalid array expression.");
+            goto end_parse;
+        }
         
         if(!RequireToken(tokenizer, "]", 0))
         {


### PR DESCRIPTION
Hey,

found 2 crashes, when:
1. Array contains invalid characters
2. Struct closing tag is '=' rather than '}'

Both crashing because `ParseExpression` returns `NULL` for both cases.

You might add error messages to it, I'm not sure where to place them.

In the 1st crash might be useful to add an appropriate message.

Here are the files causing the crash, if you want to reproduce them and fix in another way.
[crash.zip](https://github.com/ryanfleury/data_desk/files/4815855/crash.zip)
