### PR TITLE
ParseContext initializer procedure

### DIFF
--- a/docs_gen/docs_gen.c
+++ b/docs_gen/docs_gen.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include <string.h>
 
 #define ENABLE_LOG_BY_DEFAULT 1
 
@@ -529,6 +530,8 @@ int main(int argument_count, char **arguments)
     if(argument_count > 1)
     {
         ParseContext context = {0};
+        context.namespace_count = 1;
+        context.current_namespace = context.namespace_head = context.namespace_tail = &context.global_namespace;
         
         DataDeskNode *head = 0;
         DataDeskNode *tail = 0;

--- a/docs_gen/docs_gen.c
+++ b/docs_gen/docs_gen.c
@@ -530,8 +530,7 @@ int main(int argument_count, char **arguments)
     if(argument_count > 1)
     {
         ParseContext context = {0};
-        context.namespace_count = 1;
-        context.current_namespace = context.namespace_head = context.namespace_tail = &context.global_namespace;
+        ParseContextInit(&context);
         
         DataDeskNode *head = 0;
         DataDeskNode *tail = 0;

--- a/source/data_desk_main.c
+++ b/source/data_desk_main.c
@@ -195,9 +195,7 @@ main(int argument_count, char **arguments)
             }
             
             ParseContext parse_context = {0};
-            parse_context.namespace_count = 1;
-            parse_context.current_namespace = parse_context.namespace_head = parse_context.namespace_tail =
-                &parse_context.global_namespace;
+            ParseContextInit(&parse_context);
             
             int number_of_parsed_files = 0;
             struct

--- a/source/data_desk_parse.c
+++ b/source/data_desk_parse.c
@@ -66,6 +66,13 @@ struct ParseContext
 };
 
 static void
+ParseContextInit(ParseContext *context)
+{
+    context->namespace_count = 1;
+    context->current_namespace = context->namespace_head = context->namespace_tail = &context->global_namespace;
+}
+
+static void
 ParseContextCleanUp(ParseContext *context)
 {
     MemoryArenaClear(&context->arena);


### PR DESCRIPTION
I overlooked the use of `ParseContext` in the docs generator. Now that the `ParseContext` struct contains a linked list, zero initialization does not work anymore. I've added a routine to initialize it.