### PR TITLE
ParseContext namespace linked list initialization

### DIFF
--- a/docs_gen/docs_gen.c
+++ b/docs_gen/docs_gen.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include <string.h>
 
 #define ENABLE_LOG_BY_DEFAULT 1
 
@@ -529,6 +530,8 @@ int main(int argument_count, char **arguments)
     if(argument_count > 1)
     {
         ParseContext context = {0};
+        context.namespace_count = 1;
+        context.current_namespace = context.namespace_head = context.namespace_tail = &context.global_namespace;
         
         DataDeskNode *head = 0;
         DataDeskNode *tail = 0;

--- a/docs_gen/docs_gen.c
+++ b/docs_gen/docs_gen.c
@@ -530,8 +530,7 @@ int main(int argument_count, char **arguments)
     if(argument_count > 1)
     {
         ParseContext context = {0};
-        context.namespace_count = 1;
-        context.current_namespace = context.namespace_head = context.namespace_tail = &context.global_namespace;
+        ParseContextInit(&context);
         
         DataDeskNode *head = 0;
         DataDeskNode *tail = 0;

--- a/docs_gen/docs_gen.c
+++ b/docs_gen/docs_gen.c
@@ -530,7 +530,6 @@ int main(int argument_count, char **arguments)
     if(argument_count > 1)
     {
         ParseContext context = {0};
-        ParseContextInit(&context);
         
         DataDeskNode *head = 0;
         DataDeskNode *tail = 0;

--- a/source/data_desk_main.c
+++ b/source/data_desk_main.c
@@ -195,9 +195,7 @@ main(int argument_count, char **arguments)
             }
             
             ParseContext parse_context = {0};
-            parse_context.namespace_count = 1;
-            parse_context.current_namespace = parse_context.namespace_head = parse_context.namespace_tail =
-                &parse_context.global_namespace;
+            ParseContextInit(&parse_context);
             
             int number_of_parsed_files = 0;
             struct

--- a/source/data_desk_main.c
+++ b/source/data_desk_main.c
@@ -195,7 +195,6 @@ main(int argument_count, char **arguments)
             }
             
             ParseContext parse_context = {0};
-            ParseContextInit(&parse_context);
             
             int number_of_parsed_files = 0;
             struct

--- a/source/data_desk_parse.c
+++ b/source/data_desk_parse.c
@@ -66,7 +66,7 @@ struct ParseContext
 };
 
 static void
-ParseContextInit(ParseContext *context)
+ParseContextInitNamespaces(ParseContext *context)
 {
     context->namespace_count = 1;
     context->current_namespace = context->namespace_head = context->namespace_tail = &context->global_namespace;
@@ -355,6 +355,11 @@ ParseContextAllocateNode(ParseContext *context, Tokenizer *tokenizer, Token toke
     node->line = tokenizer->line;
     node->string = token.string;
     node->string_length = token.string_length;
+
+    if(context->namespace_count == 0){
+        ParseContextInitNamespaces(context);
+    }
+
     node->namespace_index = context->current_namespace->index;
 
 	if(type == DataDeskNodeType_Identifier ||
@@ -897,7 +902,7 @@ ParseCode(ParseContext *context, Tokenizer *tokenizer)
     
     Token token = {0};
 
-    context->current_namespace = &context->global_namespace;
+    context->current_namespace = &context->global_namespace; // NOTE(mal): Revert back to global_namespace for each new file
     
     do
     {
@@ -908,6 +913,10 @@ ParseCode(ParseContext *context, Tokenizer *tokenizer)
             {
                 NamespaceNode *target_namespace = 0;
 
+                if(context->namespace_count == 0){
+                    ParseContextInitNamespaces(context);
+                }
+
                 for(NamespaceNode *node = context->namespace_head->next; node; node = node->next){
                     if(StringMatchCaseSensitiveN(node->name, namespace_token.string, namespace_token.string_length) &&
                        node->name[namespace_token.string_length] == 0)
@@ -915,7 +924,6 @@ ParseCode(ParseContext *context, Tokenizer *tokenizer)
                         target_namespace = node;
                         break;
                     }
-
                 }
 
                 if(!target_namespace)

--- a/source/data_desk_parse.c
+++ b/source/data_desk_parse.c
@@ -66,6 +66,13 @@ struct ParseContext
 };
 
 static void
+ParseContextInit(ParseContext *context)
+{
+    context->namespace_count = 1;
+    context->current_namespace = context->namespace_head = context->namespace_tail = &context->global_namespace;
+}
+
+static void
 ParseContextCleanUp(ParseContext *context)
 {
     MemoryArenaClear(&context->arena);


### PR DESCRIPTION
Fixes uninitialized namespace list in docs generator (and potentially elsewhere).